### PR TITLE
install ifconfig dependency

### DIFF
--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -14,8 +14,9 @@ ENV STEAMAPPDIR /home/steam/csgo-dedicated
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends --no-install-suggests \
-		wget=1.20.1-1.1 \
 		ca-certificates=20190110 \
+		wget=1.20.1-1.1 \
+		net-tools \
 	&& mkdir -p ${STEAMAPPDIR}/csgo \
 	&& cd ${STEAMAPPDIR} \
 	&& wget https://raw.githubusercontent.com/CM2Walki/CSGO/master/etc/entry.sh \


### PR DESCRIPTION
Fixes `sh: 1: ifconfig: not found` error by installing `ifconfig` with `net-tools` package.

```
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
ILocalize::AddFile() failed to load file "public/steambootstrapper_english.txt".
[  0%] Checking for available update...
[----] Downloading update (0 of 50327 KB)...
[  0%] Downloading update (2497 of 50327 KB)...
...
[100%] Download Complete.
[----] Applying update...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Cleaning up...
[----] Update complete, launching...
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
[  0%] Downloading update...
[  0%] Checking for available updates...
[----] Download complete.
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Cleaning up...
[----] Update complete, launching Steamcmd...
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
Steam Console Client (c) Valve Corporation
-- type 'quit' to exit --
Loading Steam API...OK.

Connecting anonymously to Steam Public...Logged in OK
Waiting for user info...OK
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x61) downloading, progress: 0.00 (513052 / 23940575234)
...
 Update state (0x61) downloading, progress: 100.00 (10967976240 / 10967976240)
Success! App '740' fully installed.
CWorkThreadPool::~CWorkThreadPool: work processing queue not empty: 1 items discarded.
/home/steam/csgo-dedicated/srcds_run: 32: /home/steam/csgo-dedicated/srcds_run: pushd: not found
/home/steam/csgo-dedicated/srcds_run: 35: /home/steam/csgo-dedicated/srcds_run: popd: not found
Server will auto-restart if there is a crash.
Updating server using Steam.
----------------------------
/home/steam/csgo-dedicated/srcds_run: 1: eval: ./steam.sh: not found
----------------------------
Setting breakpad minidump AppID = 740
Using breakpad crash handler
Forcing breakpad minidump interfaces to load
dlopen failed trying to load:
/home/steam/.steam/sdk32/steamclient.so
with error:
/home/steam/.steam/sdk32/steamclient.so: cannot open shared object file: No such file or directory
Looking up breakpad interfaces from steamclient
Calling BreakpadMiniDumpSystemInit
[S_API FAIL] SteamAPI_Init() failed; SteamAPI_IsSteamRunning() failed.
[S_API FAIL] SteamAPI_Init() failed; unable to locate a running instance of Steam, or a local steamclient.so.
sh: 1: ifconfig: not found
LD_LIBRARY_PATH=/home/steam/csgo-dedicated/bin:/home/steam/csgo-dedicated:/home/steam/csgo-dedicated/bin:
#
#Console initialized.
#Using breakpad minidump system 740/13740.1056.DC
#Loading VPK file hashes for pure server operation.
#Loading VPK file hashes for pure server operation.
#Loading VPK file hashes for pure server operation.
#Loading VPK file hashes for pure server operation.
#Game.dll loaded for "Counter-Strike: Global Offensive"
#CGameEventManager::AddListener: event 'server_pre_shutdown' unknown.
#CGameEventManager::AddListener: event 'game_newmap' unknown.
#CGameEventManager::AddListener: event 'finale_start' unknown.
```