### PR TITLE
use bash and not sh so for pushd and pulld

### DIFF
--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 ${STEAMCMDDIR}/steamcmd.sh +login anonymous +force_install_dir ${STEAMAPPDIR} +app_update ${STEAMAPPID} +quit
 
 ${STEAMAPPDIR}/srcds_run -game csgo -console -autoupdate -steam_dir ${STEAMCMDDIR} -steamcmd_script ${STEAMAPPDIR}/csgo_update.txt -usercon +fps_max $SRCDS_FPSMAX \


### PR DESCRIPTION
Fixes:
- `/home/steam/csgo-dedicated/srcds_run: 32: /home/steam/csgo-dedicated/srcds_run: pushd: not found`
- `/home/steam/csgo-dedicated/srcds_run: 35: /home/steam/csgo-dedicated/srcds_run: popd: not found`

Uses `#!/bin/bash` instead of `#!/bin/sh` so `pushd` and `pulld` are available.

```
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
ILocalize::AddFile() failed to load file "public/steambootstrapper_english.txt".
[  0%] Checking for available update...
[----] Downloading update (0 of 50327 KB)...
[  0%] Downloading update (2497 of 50327 KB)...
...
[100%] Download Complete.
[----] Applying update...
[----] Extracting package...
...
[----] Extracting package...
[----] Installing update...
...
[----] Installing update...
[----] Cleaning up...
[----] Update complete, launching...
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
[  0%] Downloading update...
[  0%] Checking for available updates...
[----] Download complete.
...
[----] Extracting package...
[----] Installing update...
...
[----] Cleaning up...
[----] Update complete, launching Steamcmd...
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/steam/Steam/logs/stderr.txt'
[  0%] Checking for available updates...
[----] Verifying installation...
Steam Console Client (c) Valve Corporation
-- type 'quit' to exit --
Loading Steam API...OK.

Connecting anonymously to Steam Public...Logged in OK
Waiting for user info...OK
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x3) reconfiguring, progress: 0.00 (0 / 0)
 Update state (0x61) downloading, progress: 0.00 (513052 / 23940575234)
...
 Update state (0x61) downloading, progress: 100.00 (10967976240 / 10967976240)
Success! App '740' fully installed.
CWorkThreadPool::~CWorkThreadPool: work processing queue not empty: 1 items discarded.
/home/steam/csgo-dedicated/srcds_run: 32: /home/steam/csgo-dedicated/srcds_run: pushd: not found
/home/steam/csgo-dedicated/srcds_run: 35: /home/steam/csgo-dedicated/srcds_run: popd: not found
Server will auto-restart if there is a crash.
Updating server using Steam.
----------------------------
/home/steam/csgo-dedicated/srcds_run: 1: eval: ./steam.sh: not found
----------------------------
Setting breakpad minidump AppID = 740
Using breakpad crash handler
Forcing breakpad minidump interfaces to load
dlopen failed trying to load:
/home/steam/.steam/sdk32/steamclient.so
with error:
/home/steam/.steam/sdk32/steamclient.so: cannot open shared object file: No such file or directory
Looking up breakpad interfaces from steamclient
```